### PR TITLE
Tweak some parts stock colors to match their VAB previews

### DIFF
--- a/GameData/ReStockPBR/Patches/Aero/restock-pbr-aero-0625.cfg
+++ b/GameData/ReStockPBR/Patches/Aero/restock-pbr-aero-0625.cfg
@@ -18,7 +18,7 @@
     {
       name = main
       swatchPrimary = porkjetWhite
-      swatchSecondary = payloadGrey
+      swatchSecondary = porkjetBlack
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/Aero/restock-pbr-aero-125.cfg
+++ b/GameData/ReStockPBR/Patches/Aero/restock-pbr-aero-125.cfg
@@ -48,7 +48,7 @@
     {
       name = main
       swatchPrimary = porkjetWhite
-      swatchSecondary = payloadGrey
+      swatchSecondary = porkjetBlack
     }
   }
 }
@@ -70,7 +70,7 @@
     {
       name = main
       swatchPrimary = porkjetWhite
-      swatchSecondary = payloadGrey
+      swatchSecondary = porkjetBlack
     }
   } 
 }
@@ -169,7 +169,7 @@
     {
       name = main
       swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetBlack
+      swatchSecondary = porkjetWhite
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/Aero/restock-pbr-aero-25.cfg
+++ b/GameData/ReStockPBR/Patches/Aero/restock-pbr-aero-25.cfg
@@ -49,7 +49,7 @@
     {
       name = main
       swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetGrey
+      swatchSecondary = porkjetBlack
       transform = 25mNoseconeWhite
     }
     COLORZONE

--- a/GameData/ReStockPBR/Patches/Command/restock-external-command-seat.cfg
+++ b/GameData/ReStockPBR/Patches/Command/restock-external-command-seat.cfg
@@ -16,7 +16,7 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
+      swatchPrimary = porkjetBlack
       swatchSecondary = porkjetBlack
     }
   }

--- a/GameData/ReStockPBR/Patches/Command/restock-pbr-command-pods.cfg
+++ b/GameData/ReStockPBR/Patches/Command/restock-pbr-command-pods.cfg
@@ -125,8 +125,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetBlack
+      swatchPrimary = porkjetBlack
+      swatchSecondary = porkjetWhite
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/Control/restock-pbr-rcs.cfg
+++ b/GameData/ReStockPBR/Patches/Control/restock-pbr-rcs.cfg
@@ -42,8 +42,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = metalBasic
-      swatchSecondary = metalBasic
+      swatchPrimary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltanks-0625.cfg
+++ b/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltanks-0625.cfg
@@ -19,8 +19,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetBlack
-      swatchSecondary = porkjetWhite
+      swatchPrimary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltanks-0625.cfg
+++ b/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltanks-0625.cfg
@@ -19,8 +19,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = metalBasic
-      swatchSecondary = metalBasic
+      swatchPrimary = porkjetBlack
+      swatchSecondary = porkjetWhite
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltanks-125.cfg
+++ b/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltanks-125.cfg
@@ -209,7 +209,7 @@
     {
       name = main
       swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetBlack
+      swatchSecondary = porkjetWhite
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltanks-125.cfg
+++ b/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltanks-125.cfg
@@ -209,7 +209,7 @@
     {
       name = main
       swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/Science/restock-pbr-science.cfg
+++ b/GameData/ReStockPBR/Patches/Science/restock-pbr-science.cfg
@@ -31,8 +31,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = basicMetal
-      swatchSecondary = scienceBlue
+      swatchPrimary = porkjetGrey
+      swatchSecondary = electricalRed
     }
   }
 }
@@ -57,7 +57,7 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = basicMetal
+      swatchPrimary = porkjetGrey
       swatchSecondary = scienceBlue
     }
   }
@@ -83,8 +83,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = basicMetal
-      swatchSecondary = scienceBlue
+      swatchPrimary = porkjetGrey
+      swatchSecondary = jebsYellow
     }
   }
 }
@@ -109,7 +109,7 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = basicMetal
+      swatchPrimary = porkjetGrey
       swatchSecondary = scienceBlue
     }
   }
@@ -184,7 +184,7 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = basicMetal
+      swatchPrimary = porkjetGrey
       swatchSecondary = scienceBlue
     }
   }

--- a/GameData/ReStockPBR/Patches/Structural/restock-pbr-structural-125.cfg
+++ b/GameData/ReStockPBR/Patches/Structural/restock-pbr-structural-125.cfg
@@ -170,7 +170,7 @@
     {
       name = main
       swatchPrimary = metalBasic
-      swatchSecondary = plasticYellow
+      swatchSecondary = metalBasic
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/Utility/restock-pbr-lights.cfg
+++ b/GameData/ReStockPBR/Patches/Utility/restock-pbr-lights.cfg
@@ -187,8 +187,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = jebsYellow
-      swatchSecondary = porkjetBlack
+      swatchPrimary = porkjetBlack
+      swatchSecondary = jebsYellow
     }
   }
   
@@ -213,8 +213,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = jebsYellow
-      swatchSecondary = porkjetBlack
+      swatchPrimary = porkjetBlack
+      swatchSecondary = jebsYellow
     }
   }
 }

--- a/GameData/ReStockPBR/Patches/Utility/restock-pbr-lights.cfg
+++ b/GameData/ReStockPBR/Patches/Utility/restock-pbr-lights.cfg
@@ -29,8 +29,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchPrimary = porkjetBlack
+      swatchSecondary = porkjetBlack
     }
   }
   
@@ -55,8 +55,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchPrimary = porkjetBlack
+      swatchSecondary = porkjetBlack
     }
   }
 }
@@ -81,8 +81,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchPrimary = porkjetBlack
+      swatchSecondary = porkjetBlack
     }
   }
 }
@@ -107,8 +107,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchPrimary = porkjetBlack
+      swatchSecondary = porkjetBlack
     }
   }
 }
@@ -133,8 +133,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchPrimary = porkjetBlack
+      swatchSecondary = porkjetBlack
     }
   }
   
@@ -160,8 +160,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchPrimary = porkjetBlack
+      swatchSecondary = porkjetBlack
     }
   }
   
@@ -187,8 +187,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchPrimary = jebsYellow
+      swatchSecondary = porkjetBlack
     }
   }
   
@@ -213,8 +213,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetWhite
+      swatchPrimary = jebsYellow
+      swatchSecondary = porkjetBlack
     }
   }
 }


### PR DESCRIPTION
Just some small changes to the default colors of parts. I tested different combinations and chose what I thought matched the parts preview the best. 
Parts that have heatshield tiles are left unchanged, as changing those parts' stock colors would also change the colors of the tiles.

(as a side note - for some reason, 'Drouge Orange' isn't actually orange - it's blue, and metalBasic tends to look like porkjetWhite on the science parts)