### PR TITLE
Fix RS+ parts default colors, remove useless variants, add fuel to Mk2 Intake Adapter

### DIFF
--- a/GameData/ReStockPBR/Patches/Engines/restock-pbr-engines-liquid-125.cfg
+++ b/GameData/ReStockPBR/Patches/Engines/restock-pbr-engines-liquid-125.cfg
@@ -16,6 +16,7 @@
   {
     model = ReStockPBR/Assets/Engine/restock-pbr-engine-nerv-1
   }
+  !MODULE[ModulePartVariants] {}
   MODULE
   {
     name = ModuleTechnicolor

--- a/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltank-25.cfg
+++ b/GameData/ReStockPBR/Patches/FuelTank/restock-pbr-fueltank-25.cfg
@@ -27,19 +27,6 @@
     baseVariant = White
     VARIANT
     {
-      name = Orange
-      displayName = #LOC_RestockPBR_variant_sofi
-      primaryColor = #f49841
-      secondaryColor = #f49841
-      GAMEOBJECTS
-      {
-        25TankTinySOFI = true
-        25TankTinyWhite = false
-        25TankTinyESA = false
-      }
-    }
-    VARIANT
-    {
       name = White
       displayName = #LOC_RestockPBR_variant_bare 
       primaryColor = #ffffff
@@ -48,6 +35,19 @@
       {
         25TankTinySOFI = false
         25TankTinyWhite = true
+        25TankTinyESA = false
+      }
+    }
+    VARIANT
+    {
+      name = Orange
+      displayName = #LOC_RestockPBR_variant_sofi
+      primaryColor = #f49841
+      secondaryColor = #f49841
+      GAMEOBJECTS
+      {
+        25TankTinySOFI = true
+        25TankTinyWhite = false
         25TankTinyESA = false
       }
     }
@@ -104,19 +104,6 @@
     baseVariant = White
     VARIANT
     {
-      name = Orange
-      displayName = #LOC_RestockPBR_variant_sofi
-      primaryColor = #f49841
-      secondaryColor = #f49841
-      GAMEOBJECTS
-      {
-        25TankSmallSOFI = true
-        25TankSmallWhite = false
-        25TankSmallESA = false
-      }
-    }
-    VARIANT
-    {
       name = White
       displayName = #LOC_RestockPBR_variant_bare
       primaryColor = #ffffff
@@ -125,6 +112,19 @@
       {
         25TankSmallSOFI = false
         25TankSmallWhite = true
+        25TankSmallESA = false
+      }
+    }
+    VARIANT
+    {
+      name = Orange
+      displayName = #LOC_RestockPBR_variant_sofi
+      primaryColor = #f49841
+      secondaryColor = #f49841
+      GAMEOBJECTS
+      {
+        25TankSmallSOFI = true
+        25TankSmallWhite = false
         25TankSmallESA = false
       }
     }
@@ -181,19 +181,6 @@
     baseVariant = White
     VARIANT
     {
-      name = Orange
-      displayName = #LOC_RestockPBR_variant_sofi
-      primaryColor = #f49841
-      secondaryColor = #f49841
-      GAMEOBJECTS
-      {
-        25TankMedSOFI = true
-        25TankMedWhite = false
-        25TankMedESA = false
-      }
-    }
-    VARIANT
-    {
       name = White
       displayName = #LOC_RestockPBR_variant_bare 
       primaryColor = #ffffff
@@ -202,6 +189,19 @@
       {
         25TankMedSOFI = false
         25TankMedWhite = true
+        25TankMedESA = false
+      }
+    }
+    VARIANT
+    {
+      name = Orange
+      displayName = #LOC_RestockPBR_variant_sofi
+      primaryColor = #f49841
+      secondaryColor = #f49841
+      GAMEOBJECTS
+      {
+        25TankMedSOFI = true
+        25TankMedWhite = false
         25TankMedESA = false
       }
     }
@@ -258,19 +258,6 @@
     baseVariant = White
     VARIANT
     {
-      name = Orange
-      displayName = #LOC_RestockPBR_variant_sofi
-      primaryColor = #f49841
-      secondaryColor = #f49841
-      GAMEOBJECTS
-      {
-        25TankLargeSOFI = true
-        25TankLargeWhite = false
-        25TankLargeESA = false
-      }
-    }
-    VARIANT
-    {
       name = White
       displayName = #LOC_RestockPBR_variant_bare
       primaryColor = #ffffff
@@ -279,6 +266,19 @@
       {
         25TankLargeSOFI = false
         25TankLargeWhite = true
+        25TankLargeESA = false
+      }
+    }
+    VARIANT
+    {
+      name = Orange
+      displayName = #LOC_RestockPBR_variant_sofi
+      primaryColor = #f49841
+      secondaryColor = #f49841
+      GAMEOBJECTS
+      {
+        25TankLargeSOFI = true
+        25TankLargeWhite = false
         25TankLargeESA = false
       }
     }

--- a/GameData/ReStockPlusPBR/Parts/Aero/restock-pbr-intake-mk2-adapter-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Aero/restock-pbr-intake-mk2-adapter-1.cfg
@@ -122,8 +122,8 @@ PART
  	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 200
-		maxAmount = 200
+		amount = 250
+		maxAmount = 250
 	}
 	MODULE
 	{

--- a/GameData/ReStockPlusPBR/Parts/Aero/restock-pbr-intake-mk2-adapter-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Aero/restock-pbr-intake-mk2-adapter-1.cfg
@@ -119,6 +119,12 @@ PART
 		amount = 5
 		maxAmount = 5
 	}
+ 	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 200
+		maxAmount = 200
+	}
 	MODULE
 	{
 		name = ModuleCargoPart	

--- a/GameData/ReStockPlusPBR/Patches/Aero/restock-plus-pbr-aero-0625.cfg
+++ b/GameData/ReStockPlusPBR/Patches/Aero/restock-plus-pbr-aero-0625.cfg
@@ -9,6 +9,7 @@
   {
     model = ReStockPlusPBR/Assets/Aero/restock-pbr-nosecone-0625-2
   }
+  !MODULE[ModulePartVariants] {}
   MODULE
   {
     name = ModuleTechnicolor

--- a/GameData/ReStockPlusPBR/Patches/Control/restock-plus-pbr-rcs.cfg
+++ b/GameData/ReStockPlusPBR/Patches/Control/restock-plus-pbr-rcs.cfg
@@ -40,8 +40,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = metalBasic
-      swatchSecondary = metalBasic
+      swatchPrimary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }

--- a/GameData/ReStockPlusPBR/Patches/FuelTank/restock-plus-pbr-fueltanks-0625.cfg
+++ b/GameData/ReStockPlusPBR/Patches/FuelTank/restock-plus-pbr-fueltanks-0625.cfg
@@ -22,8 +22,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = metalBasic
-      swatchSecondary = metalBasic
+      swatchPrimary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }
@@ -43,8 +43,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = metalBasic
-      swatchSecondary = metalBasic
+      swatchPrimary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }
@@ -64,8 +64,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = metalBasic
-      swatchSecondary = metalBasic
+      swatchPrimary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }
@@ -85,8 +85,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = metalBasic
-      swatchSecondary = metalBasic
+      swatchPrimary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }

--- a/GameData/ReStockPlusPBR/Patches/Probes/restock-plus-pbr-probes.cfg
+++ b/GameData/ReStockPlusPBR/Patches/Probes/restock-plus-pbr-probes.cfg
@@ -61,8 +61,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetGrey
-      swatchSecondary = porkjetGrey
+      swatchPrimary = porkjetWhite
+      swatchSecondary = porkjetBlack
     }
   }
 }

--- a/GameData/ReStockPlusPBR/Patches/Probes/restock-plus-pbr-probes.cfg
+++ b/GameData/ReStockPlusPBR/Patches/Probes/restock-plus-pbr-probes.cfg
@@ -61,8 +61,8 @@
     COLORZONE
     {
       name = main
-      swatchPrimary = porkjetWhite
-      swatchSecondary = porkjetBlack
+      swatchPrimary = porkjetGrey
+      swatchSecondary = porkjetGrey
     }
   }
 }

--- a/GameData/ReStockPlusPBR/Patches/Structural/restock-plus-pbr-structural-375.cfg
+++ b/GameData/ReStockPlusPBR/Patches/Structural/restock-plus-pbr-structural-375.cfg
@@ -23,7 +23,7 @@
     VARIANT
     {
       name = BlackAndWhite
-      displayName = #
+      displayName = #LOC_RestockPBR_variant_bare
       primaryColor = #ffffff
       GAMEOBJECTS
       {
@@ -34,7 +34,7 @@
     VARIANT
     {
       name = Orange
-      displayName = #
+      displayName = #LOC_RestockPBR_variant_sofi
       primaryColor = #f49841
       GAMEOBJECTS
       {


### PR DESCRIPTION
I realized I forgot to check the parts in RS+ when I did my first PR, so I went back through and checked every part and changed their default swatchPrimary/swatchSecondary accordingly. Also made some other fixes along the way.

- Removed useless variants from the 'Nerv' and RS+ size0 nosecone
- Fixed missing LOC for RS+ size3 adapter
- Tweaked the ordering of the variants for the Rockomax tanks. Now they are consistent with the size3/size4 Kerbodyne tanks, with the 'Bare' variant being first and 'Insulated' being second
- Added LiquidFuel to Mk2 Intake Adapter, as its description implies it can carry "a trivial amount of jet fuel". Tank volume is copied from the Mk2 Tricoupler, which has a very similar model.