### PR TITLE
Fix missing localization on MH engines, fix variant naming on structural panels, other fixes

### DIFF
--- a/GameData/ReStockPBR/Localization/en-us.cfg
+++ b/GameData/ReStockPBR/Localization/en-us.cfg
@@ -26,5 +26,9 @@ Localization
 
     #LOC_RestockPBR_variant_jet-pylon = Pylon Mount
     #LOC_RestockPBR_variant_jet-inline = Inline Mount
+
+    #LOC_RestockPBR_variant-engine_tankbutt_size2 = Tank Butt (2.5m)
+    #LOC_RestockPBR_variant-engine_boattail_size2 = Boattail (2.5m)
+    #LOC_RestockPBR_variant-engine_boattail_size3 = Boattail (3.75m)
   }
 }

--- a/GameData/ReStockPBR/Patches/Command/restock-pbr-probes.cfg
+++ b/GameData/ReStockPBR/Patches/Command/restock-pbr-probes.cfg
@@ -362,19 +362,6 @@
     baseVariant = Bare
     VARIANT
     {
-      name = Gold
-      displayName = #LOC_Restock_variant-probe-gold
-      themeName = Gold
-      primaryColor = #fccb0a
-      GAMEOBJECTS
-      {
-        Rover_Grey = false
-        Rover_GoldFoil = true
-        Rover_Common = true
-      }
-    }
-    VARIANT
-    {
       name = Bare
       displayName = #LOC_Restock_variant-probe-bare
       primaryColor = #999999
@@ -384,6 +371,19 @@
         Rover_Grey = true
         Rover_GoldFoil = false
         Rover_Common = false
+      }
+    }
+    VARIANT
+    {
+      name = Gold
+      displayName = #LOC_Restock_variant-probe-gold
+      themeName = Gold
+      primaryColor = #fccb0a
+      GAMEOBJECTS
+      {
+        Rover_Grey = false
+        Rover_GoldFoil = true
+        Rover_Common = true
       }
     }
   }

--- a/GameData/ReStockPBR/Patches/Engines/restock-pbr-engines-liquid-0625.cfg
+++ b/GameData/ReStockPBR/Patches/Engines/restock-pbr-engines-liquid-0625.cfg
@@ -208,14 +208,13 @@
   MODULE
   {
     name = ModulePartVariants
-    baseVariant = Orange
+    baseVariant = Compact
     VARIANT
     {
-      name = Orange
-      displayName = #autoLOC_8007123
-      themeName = Orange
-      primaryColor = #f49841
-      secondaryColor = #f49841
+      name = Compact
+      displayName = #LOC_Restock_variant-engine_compact
+      primaryColor = #666666
+      secondaryColor = #999999
       GAMEOBJECTS
       {
         CompactStructureGrey = true
@@ -234,10 +233,10 @@
     }
     VARIANT
     {
-      name = OrangePodded
-      displayName = #LOC_Restock_variant-engine_pod
-      primaryColor = #f49841
-      secondaryColor = #f49841
+      name = Shrouded
+      displayName = #LOC_Restock_variant-engine_shroud
+      primaryColor = #666666
+      secondaryColor = #f69449
       GAMEOBJECTS
       {
         CompactStructureGrey = false

--- a/GameData/ReStockPBR/Patches/Engines/restock-pbr-engines-liquid-0625.cfg
+++ b/GameData/ReStockPBR/Patches/Engines/restock-pbr-engines-liquid-0625.cfg
@@ -14,6 +14,7 @@
   {
     model = ReStockPBR/Assets/Engine/restock-pbr-engine-ant-1
   }
+  !MODULE[ModulePartVariants] {}
   MODULE
   {
     name = ModuleTechnicolor

--- a/GameData/ReStockPBR/Patches/Engines/restock-pbr-mh-engines-25.cfg
+++ b/GameData/ReStockPBR/Patches/Engines/restock-pbr-mh-engines-25.cfg
@@ -20,7 +20,7 @@
     {
       // AKA 2.5m boattail (wtf)
       name = Shroud
-      displayName =  #LOC_Restock_variant-engine_tankbutt_size2
+      displayName =  #LOC_RestockPBR_variant-engine_tankbutt_size2
       themeName = Shroud
       primaryColor = #999999
       secondaryColor = #ffffff
@@ -218,7 +218,7 @@
     VARIANT
     {
       name = Full
-      displayName = #LOC_Restock_variant-engine_boattail_size2
+      displayName = #LOC_RestockPBR_variant-engine_boattail_size2
       primaryColor = #999999
       sizeGroup = GroupA
       GAMEOBJECTS
@@ -250,7 +250,7 @@
     VARIANT
     {
       name = 375Boat
-      displayName =  #LOC_Restock_variant-engine_boattail_size3
+      displayName =  #LOC_RestockPBR_variant-engine_boattail_size3
       primaryColor = #666666
       sizeGroup = GroupB
       GAMEOBJECTS

--- a/GameData/ReStockPBR/Patches/Structural/restock-pbr-structural-375.cfg
+++ b/GameData/ReStockPBR/Patches/Structural/restock-pbr-structural-375.cfg
@@ -32,7 +32,7 @@
     VARIANT
     {
       name = BlackAndWhite
-      displayName = #autoLOC_8007122
+      displayName = #LOC_RestockPBR_variant_bare
       primaryColor = #ffffff
       GAMEOBJECTS
       {
@@ -43,7 +43,7 @@
     VARIANT
     {
       name = Orange
-      displayName = #autoLOC_8007123
+      displayName = #LOC_RestockPBR_variant_sofi
       primaryColor = #f49841
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-0625-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-0625-1.cfg
@@ -59,7 +59,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-125-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-125-1.cfg
@@ -59,7 +59,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-1875-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-1875-1.cfg
@@ -59,7 +59,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-25-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-25-1.cfg
@@ -59,7 +59,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-0625-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-0625-1.cfg
@@ -54,7 +54,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-125-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-125-1.cfg
@@ -54,7 +54,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-1875-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-1875-1.cfg
@@ -54,7 +54,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-25-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-25-1.cfg
@@ -53,7 +53,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-equi-0625-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-equi-0625-1.cfg
@@ -71,7 +71,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-equi-125-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-equi-125-1.cfg
@@ -70,7 +70,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-equi-1875-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-equi-1875-1.cfg
@@ -82,7 +82,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {

--- a/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-equi-25-1.cfg
+++ b/GameData/ReStockPlusPBR/Parts/Structural/restock-pbr-panel-triangle-equi-25-1.cfg
@@ -70,7 +70,7 @@ PART
     VARIANT
     {
       name = Basic
-      displayName = #LOC_RestockPBR_variant_bare
+      displayName = #LOC_Restock_variant-surface_basic
       primaryColor = #6f6e6d
       GAMEOBJECTS
       {


### PR DESCRIPTION
Add 3 new LOCs to en-us.cfg to account for the new variant titles
Fix inconsistent variant ordering on Rovemate
Remove useless variants from Ant
Fix duplicate variant titles on structural panels - now the default variant is 'Basic'
Fix inconsistent variant naming on 3.75m adapter tank
Update Twitch engine - now has 'Compact' and 'Shrouded' variants, with adjusted variant display colors

Wanted to get this PR in before I went to bed, in case any new commits happen to be made.